### PR TITLE
Reorganize the bindings in the sys crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/google/tensorflow-rust"
 
 [dependencies]
 libc = "0.2"
-tensorflow-sys = { version = "0.4", path = "tensorflow-sys" }
+tensorflow-sys = { version = "0.4.1", path = "tensorflow-sys" }
 
 [dev-dependencies]
 random = "0.12"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,7 +354,7 @@ impl Session {
           dims.push(tf::TF_Dim(input_tensor, i as c_int));
         }
         input_tensors.push(tf::TF_NewTensor(tf::TF_TensorType(input_tensor),
-                                            dims.as_mut_ptr(),
+                                            dims.as_ptr(),
                                             dims.len() as c_int,
                                             tf::TF_TensorData(input_tensor),
                                             tf::TF_TensorByteSize(input_tensor),
@@ -638,7 +638,7 @@ impl<T: TensorType> Tensor<T> {
     }
     let inner = unsafe {
       tf::TF_NewTensor(mem::transmute(T::data_type().to_int()),
-                       dims.as_ptr() as *mut _,
+                       dims.as_ptr() as *const _,
                        dims.len() as c_int,
                        data.as_ptr() as *mut _,
                        data.len(),

--- a/tensorflow-sys/Cargo.toml
+++ b/tensorflow-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tensorflow-sys"
-version = "0.4.0"
+version = "0.4.1"
 license = "Apache-2.0"
 authors = [
   "Adam Crume <acrume@google.com>",

--- a/tensorflow-sys/examples/multiplication.rs
+++ b/tensorflow-sys/examples/multiplication.rs
@@ -1,7 +1,7 @@
 extern crate libc;
 extern crate tensorflow_sys as ffi;
 
-use libc::{c_int, c_longlong, c_void, size_t};
+use libc::{c_int, c_void, int64_t, size_t};
 use std::ffi::{CStr, CString};
 use std::path::Path;
 
@@ -40,20 +40,20 @@ fn main() {
 
         let name = CString::new("a").unwrap();
         let mut data = vec![1f32, 2.0, 3.0];
-        let mut dims = vec![data.len() as c_longlong];
-        let tensor = nonnull!(ffi::TF_NewTensor(ffi::TF_FLOAT, dims.as_mut_ptr(),
-                                                dims.len() as c_int, data.as_mut_ptr() as *mut _,
-                                                data.len() as size_t, Some(noop), null_mut()));
+        let dims = vec![data.len() as int64_t];
+        let tensor = nonnull!(ffi::TF_NewTensor(ffi::TF_FLOAT, dims.as_ptr(), dims.len() as c_int,
+                                                data.as_mut_ptr() as *mut _, data.len() as size_t,
+                                                Some(noop), null_mut()));
 
         input_names.push(name.as_ptr());
         inputs.push(tensor);
 
         let name = CString::new("b").unwrap();
         let mut data = vec![4f32, 5.0, 6.0];
-        let mut dims = vec![data.len() as c_longlong];
-        let tensor = nonnull!(ffi::TF_NewTensor(ffi::TF_FLOAT, dims.as_mut_ptr(),
-                                                dims.len() as c_int, data.as_mut_ptr() as *mut _,
-                                                data.len() as size_t, Some(noop), null_mut()));
+        let dims = vec![data.len() as int64_t];
+        let tensor = nonnull!(ffi::TF_NewTensor(ffi::TF_FLOAT, dims.as_ptr(), dims.len() as c_int,
+                                                data.as_mut_ptr() as *mut _, data.len() as size_t,
+                                                Some(noop), null_mut()));
 
         input_names.push(name.as_ptr());
         inputs.push(tensor);

--- a/tensorflow-sys/src/lib.rs
+++ b/tensorflow-sys/src/lib.rs
@@ -6,7 +6,38 @@
 
 extern crate libc;
 
-use libc::{c_char, c_int, c_longlong, c_void, size_t};
+use libc::{c_char, c_int, c_void, int64_t, size_t};
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct TF_Buffer {
+    pub data: *const c_void,
+    pub length: size_t,
+    pub data_deallocator: Option<unsafe extern "C" fn(data: *mut c_void, length: size_t)>,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TF_Code {
+    TF_OK = 0,
+    TF_CANCELLED = 1,
+    TF_UNKNOWN = 2,
+    TF_INVALID_ARGUMENT = 3,
+    TF_DEADLINE_EXCEEDED = 4,
+    TF_NOT_FOUND = 5,
+    TF_ALREADY_EXISTS = 6,
+    TF_PERMISSION_DENIED = 7,
+    TF_UNAUTHENTICATED = 16,
+    TF_RESOURCE_EXHAUSTED = 8,
+    TF_FAILED_PRECONDITION = 9,
+    TF_ABORTED = 10,
+    TF_OUT_OF_RANGE = 11,
+    TF_UNIMPLEMENTED = 12,
+    TF_INTERNAL = 13,
+    TF_UNAVAILABLE = 14,
+    TF_DATA_LOSS = 15,
+}
+pub use TF_Code::*;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -33,127 +64,82 @@ pub enum TF_DataType {
 }
 pub use TF_DataType::*;
 
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum TF_Code {
-    TF_OK = 0,
-    TF_CANCELLED = 1,
-    TF_UNKNOWN = 2,
-    TF_INVALID_ARGUMENT = 3,
-    TF_DEADLINE_EXCEEDED = 4,
-    TF_NOT_FOUND = 5,
-    TF_ALREADY_EXISTS = 6,
-    TF_PERMISSION_DENIED = 7,
-    TF_UNAUTHENTICATED = 16,
-    TF_RESOURCE_EXHAUSTED = 8,
-    TF_FAILED_PRECONDITION = 9,
-    TF_ABORTED = 10,
-    TF_OUT_OF_RANGE = 11,
-    TF_UNIMPLEMENTED = 12,
-    TF_INTERNAL = 13,
-    TF_UNAVAILABLE = 14,
-    TF_DATA_LOSS = 15,
-}
-pub use TF_Code::*;
-
-#[derive(Clone, Copy, Debug)]
-pub enum TF_Status {}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug)]
-pub struct TF_Buffer {
-  pub data: *const c_void,
-  pub length: size_t,
-  pub data_deallocator: Option<unsafe extern "C" fn(data: *mut c_void, length: size_t)>,
-}
-
 #[derive(Clone, Copy, Debug)]
 pub enum TF_Library {}
 
 #[derive(Clone, Copy, Debug)]
-pub enum TF_Tensor {}
+pub enum TF_Session {}
 
 #[derive(Clone, Copy, Debug)]
 pub enum TF_SessionOptions {}
 
 #[derive(Clone, Copy, Debug)]
-pub enum TF_Session {}
+pub enum TF_Status {}
+
+#[derive(Clone, Copy, Debug)]
+pub enum TF_Tensor {}
 
 extern "C" {
-    pub fn TF_NewBufferFromString(proto: *const c_void, proto_len: size_t) -> *mut TF_Buffer;
-
     pub fn TF_NewBuffer() -> *mut TF_Buffer;
-
+    pub fn TF_NewBufferFromString(proto: *const c_void, length: size_t) -> *mut TF_Buffer;
     pub fn TF_DeleteBuffer(buffer: *mut TF_Buffer);
-
     pub fn TF_GetBuffer(buffer: *mut TF_Buffer) -> TF_Buffer;
+}
 
-    pub fn TF_NewStatus() -> *mut TF_Status;
+extern "C" {
+    pub fn TF_LoadLibrary(name: *const c_char, status: *mut TF_Status) -> *mut TF_Library;
+    pub fn TF_GetOpList(library: *mut TF_Library) -> TF_Buffer;
+}
 
-    pub fn TF_DeleteStatus(status: *mut TF_Status);
-
-    pub fn TF_SetStatus(status: *mut TF_Status, code: TF_Code, msg: *const c_char);
-
-    pub fn TF_GetCode(status: *const TF_Status) -> TF_Code;
-
-    pub fn TF_Message(status: *const TF_Status) -> *const c_char;
-
-    pub fn TF_NewTensor(datatype: TF_DataType, dims: *mut c_longlong, num_dims: c_int,
-                        data: *mut c_void, len: size_t,
-                        deallocator: Option<unsafe extern "C" fn(data: *mut c_void, len: size_t,
-                                                                 arg: *mut c_void)>,
-                        deallocator_arg: *mut c_void) -> *mut TF_Tensor;
-
-    pub fn TF_DeleteTensor(tensor: *mut TF_Tensor);
-
-    pub fn TF_TensorType(tensor: *const TF_Tensor) -> TF_DataType;
-
-    pub fn TF_NumDims(tensor: *const TF_Tensor) -> c_int;
-
-    pub fn TF_Dim(tensor: *const TF_Tensor, dim_index: c_int) -> c_longlong;
-
-    pub fn TF_TensorByteSize(tensor: *const TF_Tensor) -> size_t;
-
-    pub fn TF_TensorData(tensor: *const TF_Tensor) -> *mut c_void;
-
-    pub fn TF_NewSessionOptions() -> *mut TF_SessionOptions;
-
-    pub fn TF_SetTarget(options: *mut TF_SessionOptions, target: *const c_char);
-
-    pub fn TF_SetConfig(options: *mut TF_SessionOptions, proto: *const c_void, proto_len: size_t,
-                        status: *mut TF_Status);
-
-    pub fn TF_DeleteSessionOptions(options: *mut TF_SessionOptions);
-
+extern "C" {
     pub fn TF_NewSession(options: *const TF_SessionOptions, status: *mut TF_Status)
                          -> *mut TF_Session;
-
-    pub fn TF_CloseSession(session: *mut TF_Session, status: *mut TF_Status);
-
     pub fn TF_DeleteSession(session: *mut TF_Session, status: *mut TF_Status);
-
-    pub fn TF_ExtendGraph(session: *mut TF_Session, proto: *const c_void, proto_len: size_t,
+    pub fn TF_CloseSession(session: *mut TF_Session, status: *mut TF_Status);
+    pub fn TF_ExtendGraph(session: *mut TF_Session, proto: *const c_void, length: size_t,
                           status: *mut TF_Status);
-
     pub fn TF_Run(session: *mut TF_Session, run_options: *const TF_Buffer,
                   input_names: *mut *const c_char, inputs: *mut *mut TF_Tensor, ninputs: c_int,
-                  output_tensor_names: *mut *const c_char, outputs: *mut *mut TF_Tensor,
-                  noutputs: c_int, target_node_names: *mut *const c_char, ntargets: c_int,
-                  run_metadata: *mut TF_Buffer, status: *mut TF_Status);
-
+                  output_names: *mut *const c_char, outputs: *mut *mut TF_Tensor, noutputs: c_int,
+                  target_names: *mut *const c_char, ntargets: c_int, run_metadata: *mut TF_Buffer,
+                  status: *mut TF_Status);
     pub fn TF_PRunSetup(session: *mut TF_Session, input_names: *mut *const c_char, ninputs: c_int,
-                        output_tensor_names: *mut *const c_char, noutputs: c_int,
-                        target_node_names: *mut *const c_char, ntargets: c_int,
-                        handle: *mut *mut c_char, status: *mut TF_Status);
-
+                        output_names: *mut *const c_char, noutputs: c_int,
+                        target_names: *mut *const c_char, ntargets: c_int,
+                        handle: *mut *const c_char, status: *mut TF_Status);
     pub fn TF_PRun(session: *mut TF_Session, handle: *const c_char,
                    input_names: *mut *const c_char, inputs: *mut *mut TF_Tensor, ninputs: c_int,
-                   output_tensor_names: *mut *const c_char, outputs: *mut *mut TF_Tensor,
-                   noutputs: c_int, target_node_names: *mut *const c_char, ntargets: c_int,
-                   status: *mut TF_Status);
+                   output_names: *mut *const c_char, outputs: *mut *mut TF_Tensor, noutputs: c_int,
+                   target_names: *mut *const c_char, ntargets: c_int, status: *mut TF_Status);
+}
 
-    pub fn TF_LoadLibrary(library_filename: *const c_char, status: *mut TF_Status)
-                          -> *mut TF_Library;
+extern "C" {
+    pub fn TF_NewSessionOptions() -> *mut TF_SessionOptions;
+    pub fn TF_DeleteSessionOptions(options: *mut TF_SessionOptions);
+    pub fn TF_SetTarget(options: *mut TF_SessionOptions, target: *const c_char);
+    pub fn TF_SetConfig(options: *mut TF_SessionOptions, proto: *const c_void, length: size_t,
+                        status: *mut TF_Status);
+}
 
-    pub fn TF_GetOpList(lib_handle: *mut TF_Library) -> TF_Buffer;
+extern "C" {
+    pub fn TF_NewStatus() -> *mut TF_Status;
+    pub fn TF_DeleteStatus(status: *mut TF_Status);
+    pub fn TF_SetStatus(status: *mut TF_Status, code: TF_Code, message: *const c_char);
+    pub fn TF_GetCode(status: *const TF_Status) -> TF_Code;
+    pub fn TF_Message(status: *const TF_Status) -> *const c_char;
+}
+
+extern "C" {
+    pub fn TF_NewTensor(datatype: TF_DataType, dims: *const int64_t, ndims: c_int,
+                        data: *mut c_void, length: size_t,
+                        deallocator: Option<unsafe extern "C" fn(data: *mut c_void,
+                                                                 length: size_t,
+                                                                 arg: *mut c_void)>,
+                        deallocator_arg: *mut c_void) -> *mut TF_Tensor;
+    pub fn TF_DeleteTensor(tensor: *mut TF_Tensor);
+    pub fn TF_TensorType(tensor: *const TF_Tensor) -> TF_DataType;
+    pub fn TF_NumDims(tensor: *const TF_Tensor) -> c_int;
+    pub fn TF_Dim(tensor: *const TF_Tensor, index: c_int) -> int64_t;
+    pub fn TF_TensorByteSize(tensor: *const TF_Tensor) -> size_t;
+    pub fn TF_TensorData(tensor: *const TF_Tensor) -> *mut c_void;
 }


### PR DESCRIPTION
Anticipating the graph API that will be shipped with the next release of TensorFlow, I’ve started to reorganize the bindings in the sys crate in order to make the maintenance easier and the future extension more systematic. The types are now alphabetically sorted, and the functions are now grouped by the data structures that there are concerned with.

In addition, I’ve proactively made the following changes:

* use `int64_t` instead of `c_longlong`;
* change `TF_NewTensor`’s `dims` from `*mut _` to `*const _`; and
* change `TF_PRunSetup`’s `handle` from `*mut *mut _` to `*mut *const _`.

All of them are perfectly valid with the current version of TensorFlow, version 0.9. You can see individual commits in the [commit history](https://github.com/stainless-steel/tensorflux-sys/commits/master) of `tensorflux-sys`.

Regards,
Ivan