### PR TITLE
Depend on num-complex instead of num

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/google/tensorflow-rust"
 
 [dependencies]
 libc = "0.2"
-num = "0.1.34"
+num-complex = { version = "0.1.35", default-features = false }
 tensorflow-sys = { version = "0.4.1", path = "tensorflow-sys" }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,11 @@
 //! This crate provides Rust bindings for the [TensorFlow](https://www.tensorflow.org) machine learning library.
 
 extern crate libc;
-extern crate num;
+extern crate num_complex;
 extern crate tensorflow_sys as tf;
 
 use libc::{c_char, c_int, c_uint, c_void, size_t};
-use num::Complex;
+use num_complex::Complex;
 use std::error::Error;
 use std::ffi::CStr;
 use std::ffi::CString;


### PR DESCRIPTION
By depending on `num-complex` directly, one can eliminate the need to download and compile such redundant crates as `num-bigint`, `num-integer`, `num-iter`, `num-rational`, and `rustc-serialize`.

Regards,
Ivan