### PR TITLE
Ignore Intellij project files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 Cargo.lock
 target
 travis-ci/travis_rsa
+**/*.iml
+.idea


### PR DESCRIPTION
I'm using IntelliJ with the rust plugin for development, I think it makes sense to add those to the .gitignore.